### PR TITLE
docs: update maintainer name to david raynes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owner
+* @rayners

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing
+
+Thanks for your interest in improving `@rayners/foundry-module-types`! This guide outlines
+how to propose changes and the expectations for contributors.
+
+## Code of Conduct
+
+Please be respectful and collaborative when interacting with maintainers and other
+contributors. Report any inappropriate behaviour to the repository maintainers.
+
+## Getting Started
+
+1. Fork the repository and clone your fork locally.
+2. Install dependencies with `npm install` (Node.js 18 or newer is required).
+3. Create a new branch for your change.
+
+## Development Workflow
+
+- Keep pull requests focused and provide context in the description for the change.
+- Ensure TypeScript definitions remain backwards compatible unless a breaking change is
+  coordinated with the maintainers.
+- Update documentation when you add new types or exports.
+
+## Required Checks
+
+Run the following commands and make sure they succeed before opening a pull request:
+
+```bash
+npm run lint
+npm run typecheck
+npm run build
+```
+
+CI will run these commands as well, so passing them locally saves time for reviewers.
+
+## Commit Guidelines
+
+- Write clear commit messages that describe _why_ the change is necessary.
+- Keep commits logically scoped; avoid combining unrelated changes in a single commit.
+- Reference relevant issues in your pull request description.
+
+Thank you for helping make these shared types better for everyone!

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 David Raynes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,73 @@
+# @rayners/foundry-module-types
+
+Shared TypeScript declarations for David Raynes' suite of Foundry Virtual Tabletop modules.
+
+## Installation
+
+Install the package as a development dependency so your TypeScript project can rely on the
+published declaration files:
+
+```bash
+npm install --save-dev @rayners/foundry-module-types
+```
+
+The package targets Node.js 18+ environments in alignment with Foundry VTT's current
+requirements.
+
+## Usage
+
+Import the modules that your project depends on to gain typed access to their public APIs.
+Every module exports namespaces that mirror the structure of the deployed Foundry modules.
+
+```ts
+import { Foundry, SeasonsAndStars, TaskAndTrigger } from '@rayners/foundry-module-types';
+
+function registerSetting(settings: Foundry.ClientSettings) {
+  settings.register('task-and-trigger', 'autoAssignTasks', {
+    scope: 'world',
+    config: true,
+    type: Boolean,
+    default: true,
+  });
+}
+
+const travelRoles: SeasonsAndStars.TravelRole[] = [
+  {
+    id: 'scout',
+    name: 'Scout',
+    description: 'Keeps a lookout for trouble while the company travels.',
+  },
+];
+
+const trigger: TaskAndTrigger.TaskTrigger = {
+  id: 'restock-herbs',
+  name: 'Restock Herbs',
+  frequency: 'weekly',
+  execute: async () => {
+    // Custom campaign logic here.
+  },
+};
+```
+
+Available namespaces include:
+
+- `Foundry` – Lightweight primitives that model the Foundry VTT runtime.
+- `SeasonsAndStars` – Types shared by the **Seasons & Stars** module.
+- `SimpleCalendarCompat` – Helpers for interoperability with Simple Calendar.
+- `JourneysAndJamborees` – Journeys & Jamborees module types.
+- `RealmsAndReaches` – Shared declarations for the Realms & Reaches module.
+- `TaskAndTrigger` – Task automation and scheduler primitives.
+- `ErrorsAndEchoes` – Utilities for the Errors & Echoes module.
+
+Check the [`src/`](./src) directory for the latest source of truth. The compiled
+`.d.ts` files emitted to `dist/` are published with each release.
+
+## Contributing
+
+Community contributions are welcome! Please review [CONTRIBUTING.md](./CONTRIBUTING.md) for
+information on setting up your local environment, coding standards, and required checks
+before opening a pull request.
+
+## License
+
+This project is distributed under the terms of the [MIT License](./LICENSE).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rayners/foundry-module-types",
   "version": "0.1.0",
-  "description": "Shared TypeScript declarations for Rayners' suite of Foundry VTT modules.",
+  "description": "Shared TypeScript declarations for David Raynes' suite of Foundry VTT modules.",
   "type": "module",
   "files": [
     "dist"
@@ -51,7 +51,7 @@
     "foundryvtt",
     "types"
   ],
-  "author": "Rayner R. <rayners@users.noreply.github.com>",
+  "author": "David Raynes <rayners@users.noreply.github.com>",
   "license": "MIT",
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary
- update README and package metadata to reference David Raynes by name
- adjust MIT license copyright notice to the owner's full name

## Testing
- npm run lint
- npm run typecheck
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cce586c92c8327a0b91c73e2a5a7ab